### PR TITLE
fix: wbs초기실행시 리스트가 중복되던 현상 해결

### DIFF
--- a/app/src/main/java/com/khupearl/smp/wbs/list/DoneFragment.java
+++ b/app/src/main/java/com/khupearl/smp/wbs/list/DoneFragment.java
@@ -56,14 +56,12 @@ public class DoneFragment extends Fragment {
         wbsListRecyclerView = view.findViewById(R.id.recyclerview_wbs_done);
         linearLayoutManager = new LinearLayoutManager(getActivity());
         wbsListRecyclerView.setLayoutManager(linearLayoutManager);
-
-        getWorkList(teamName, wbsState);
     }
 
     @Override
     public void onResume() {
         super.onResume();
-        workArrayList= new ArrayList<>();
+        workArrayList.clear();
         getWorkList(teamName, wbsState);
     }
 

--- a/app/src/main/java/com/khupearl/smp/wbs/list/InprogressFragment.java
+++ b/app/src/main/java/com/khupearl/smp/wbs/list/InprogressFragment.java
@@ -56,14 +56,12 @@ public class InprogressFragment extends Fragment {
         wbsListRecyclerView = view.findViewById(R.id.recyclerview_wbs_inprogress);
         linearLayoutManager = new LinearLayoutManager(getActivity());
         wbsListRecyclerView.setLayoutManager(linearLayoutManager);
-
-        getWorkList(teamName, wbsState);
     }
 
     @Override
     public void onResume() {
         super.onResume();
-        workArrayList= new ArrayList<>();
+        workArrayList.clear();
         getWorkList(teamName, wbsState);
     }
 

--- a/app/src/main/java/com/khupearl/smp/wbs/list/TodoFragment.java
+++ b/app/src/main/java/com/khupearl/smp/wbs/list/TodoFragment.java
@@ -56,14 +56,12 @@ public class TodoFragment extends Fragment {
         wbsListRecyclerView = view.findViewById(R.id.recyclerview_wbs_todo);
         linearLayoutManager = new LinearLayoutManager(getActivity());
         wbsListRecyclerView.setLayoutManager(linearLayoutManager);
-
-        getWorkList(teamName, wbsState);
     }
 
     @Override
     public void onResume() {
         super.onResume();
-        workArrayList= new ArrayList<>();
+        workArrayList.clear();
         getWorkList(teamName, wbsState);
     }
 


### PR DESCRIPTION
wbs 최초 실행시 리스트가 중복되었다!

이유는 `resume`에서 `getWorkList`를 호출하는데, `init`에서도 `getWorkList`를 호출하기 때문에 첫 1회에는 두 번 실행돼서 같은 내용이 2개씩 떴다!

`workArrayList` 는 `new ArrayList`로 재선언 해줬었는데, `clear`메서드를 활용하는걸로 바꿨다. 무한 메모리 재할당에서 벗어났다!